### PR TITLE
ServiceUrlNotWorkingWhenEndingSlashIsMissing

### DIFF
--- a/Client.Common.Tests/Services/SubsonicServiceConfigurationTests.cs
+++ b/Client.Common.Tests/Services/SubsonicServiceConfigurationTests.cs
@@ -23,5 +23,13 @@ namespace Client.Common.Tests.Services
 
             _subject.EncodedCredentials().Should().Be("QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         }
+
+        [TestMethod]
+        public void BaseUrl_IfDoesNotHaveEndingSlash_WillAddEndingSlash()
+        {
+            _subject.BaseUrl = "http://localhost:4040";
+
+            _subject.BaseUrl.Should().Be("http://localhost:4040/");
+        }
     }
 }

--- a/Client.Common/Services/SubsonicServiceConfiguration.cs
+++ b/Client.Common/Services/SubsonicServiceConfiguration.cs
@@ -44,7 +44,7 @@ namespace Client.Common.Services
             set
             {
                 if (value == _baseUrl) return;
-                _baseUrl = value;
+                _baseUrl = AddEndingSlashIfNotExisting(value);
                 NotifyOfPropertyChange();
             }
         }
@@ -53,6 +53,17 @@ namespace Client.Common.Services
         {
             byte[] bytes = System.Text.Encoding.UTF8.GetBytes(string.Format("{0}:{1}", Username, Password));
             return System.Convert.ToBase64String(bytes);
+        }
+
+        private string AddEndingSlashIfNotExisting(string value)
+        {
+            var result = value;
+            if (!string.IsNullOrEmpty(value) && result.LastIndexOf("/", System.StringComparison.Ordinal) != result.Length - 1)
+            {
+                result = string.Format("{0}/", result);
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
[BugFix] When user inputs service url without ending slash, it will be a valid address
