### PR TITLE
Navidrome support

### DIFF
--- a/Client.Common.Tests/Models/Subsonic/MusicDirectoryTests.cs
+++ b/Client.Common.Tests/Models/Subsonic/MusicDirectoryTests.cs
@@ -19,7 +19,7 @@
         public void GetDescription_Always_ReturnsTheCorrectValue()
         {
             _subject.Name = "test";
-            _subject.Id = 2;
+            _subject.Id = "2";
 
             var description = _subject.GetDescription();
 

--- a/Client.Common.Tests/Results/CreatePlaylistResultTests.cs
+++ b/Client.Common.Tests/Results/CreatePlaylistResultTests.cs
@@ -21,7 +21,7 @@
 
         #region Fields
 
-        private List<int> _songIds;
+        private List<string> _songIds;
 
         private CreatePlaylistResultWrapper _subject;
 
@@ -32,14 +32,14 @@
         [TestInitialize]
         public void Setup()
         {
-            _songIds = new List<int>();
+            _songIds = new List<string>();
             _subject = new CreatePlaylistResultWrapper(new SubsonicServiceConfiguration(), "test playlist", _songIds);
         }
 
         [TestMethod]
         public void HandleResponse_ResponseIsEmpty_ReturnsTrue()
         {
-            var result = new CreatePlaylistResultWrapper(new SubsonicServiceConfiguration(), string.Empty, new int[0]);
+            var result = new CreatePlaylistResultWrapper(new SubsonicServiceConfiguration(), string.Empty, new string[0]);
 
             result.CallHandleResponse(XDocument.Load(new StringReader(Data)));
 
@@ -49,7 +49,7 @@
         [TestMethod]
         public void RequestUrlShouldBeCorrect()
         {
-            _songIds.AddRange(Enumerable.Range(0, 5));
+            _songIds.AddRange(new[] { "0", "1", "2", "3", "4" });
 
             _subject.RequestUrl.Should().EndWith("&name=test+playlist&songId=0&songId=1&songId=2&songId=3&songId=4");
         }
@@ -67,7 +67,7 @@
             #region Constructors and Destructors
 
             public CreatePlaylistResultWrapper(
-                ISubsonicServiceConfiguration configuration, string name, IEnumerable<int> songIds)
+                ISubsonicServiceConfiguration configuration, string name, IEnumerable<string> songIds)
                 : base(configuration, name, songIds)
             {
             }

--- a/Client.Common.Tests/Results/DeletePlaylistResultTests.cs
+++ b/Client.Common.Tests/Results/DeletePlaylistResultTests.cs
@@ -29,13 +29,13 @@
         public void Setup()
         {
             var subsonicServiceConfiguration = new SubsonicServiceConfiguration();
-            _subject = new DeletePlaylistResultWrapper(subsonicServiceConfiguration, 1);
+            _subject = new DeletePlaylistResultWrapper(subsonicServiceConfiguration, "1");
         }
 
         [TestMethod]
         public void HandleResponse_ResponseIsEmpty_ReturnsTrue()
         {
-            var result = new DeletePlaylistResultWrapper(new SubsonicServiceConfiguration(), 1);
+            var result = new DeletePlaylistResultWrapper(new SubsonicServiceConfiguration(), "1");
 
             result.CallHandleResponse(XDocument.Load(new StringReader(Data)));
 
@@ -60,7 +60,7 @@
         {
             #region Constructors and Destructors
 
-            public DeletePlaylistResultWrapper(ISubsonicServiceConfiguration configuration, int id)
+            public DeletePlaylistResultWrapper(ISubsonicServiceConfiguration configuration, string id)
                 : base(configuration, id)
             {
             }

--- a/Client.Common.Tests/Results/GetAlbumResultTests.cs
+++ b/Client.Common.Tests/Results/GetAlbumResultTests.cs
@@ -25,7 +25,7 @@
         [TestInitialize]
         public void TestInitialize()
         {
-            _subject = new GetAlbumResult(new SubsonicServiceConfiguration { BaseUrl = "http://test" }, 12);
+            _subject = new GetAlbumResult(new SubsonicServiceConfiguration { BaseUrl = "http://test" }, "12");
         }
 
         [TestMethod]

--- a/Client.Common.Tests/Results/GetIndexResultTests.cs
+++ b/Client.Common.Tests/Results/GetIndexResultTests.cs
@@ -25,7 +25,7 @@
         [TestInitialize]
         public void Setup()
         {
-            _subject = new GetIndexResult(new SubsonicServiceConfiguration { BaseUrl = "http://test" }, 1);
+            _subject = new GetIndexResult(new SubsonicServiceConfiguration { BaseUrl = "http://test" }, "1");
         }
 
         [TestMethod]

--- a/Client.Common.Tests/Results/GetMusicDirectoryResultTests.cs
+++ b/Client.Common.Tests/Results/GetMusicDirectoryResultTests.cs
@@ -25,7 +25,7 @@
         [TestInitialize]
         public void TestInitialize()
         {
-            _subject = new GetMusicDirectoryResult(new SubsonicServiceConfiguration { BaseUrl = "http://test" }, 42);
+            _subject = new GetMusicDirectoryResult(new SubsonicServiceConfiguration { BaseUrl = "http://test" }, "42");
         }
 
         [TestMethod]

--- a/Client.Common.Tests/Results/GetPlaylistResultTests.cs
+++ b/Client.Common.Tests/Results/GetPlaylistResultTests.cs
@@ -33,7 +33,7 @@
         [TestMethod]
         public void HandleResponse_Always_CanDeserializeAPlaylistEntryProperly()
         {
-            var result = new GetPlaylistResultWrapper(new SubsonicServiceConfiguration(), 1);
+            var result = new GetPlaylistResultWrapper(new SubsonicServiceConfiguration(), "1");
 
             result.CallHandleResponse(XDocument.Load(new StringReader(Data)));
 
@@ -47,7 +47,7 @@
         {
             #region Constructors and Destructors
 
-            public GetPlaylistResultWrapper(ISubsonicServiceConfiguration configuration, int id)
+            public GetPlaylistResultWrapper(ISubsonicServiceConfiguration configuration, string id)
                 : base(configuration, id)
             {
             }

--- a/Client.Common.Tests/Results/GetRandomSongsResultTests.cs
+++ b/Client.Common.Tests/Results/GetRandomSongsResultTests.cs
@@ -28,7 +28,7 @@
 
             _subject.Result.Should().NotBeNull();
             _subject.Result.Count.Should().Be(2);
-            _subject.Result[0].Id.Should().Be(111);
+            _subject.Result[0].Id.Should().Be("111");
         }
 
         internal class ResultWrapper : GetRandomSongsResult

--- a/Client.Common.Tests/Results/GetSongResultTests.cs
+++ b/Client.Common.Tests/Results/GetSongResultTests.cs
@@ -25,7 +25,7 @@
         [TestInitialize]
         public void TestInitialize()
         {
-            _subject = new GetSongResult(new SubsonicServiceConfiguration { BaseUrl = "http://test" }, 12);
+            _subject = new GetSongResult(new SubsonicServiceConfiguration { BaseUrl = "http://test" }, "12");
         }
 
         [TestMethod]

--- a/Client.Common.Tests/Results/RenamePlaylistResultTests.cs
+++ b/Client.Common.Tests/Results/RenamePlaylistResultTests.cs
@@ -20,7 +20,7 @@
 
         #region Fields
 
-        private List<int> _songIdsToAdd;
+        private List<string> _songIdsToAdd;
 
         private List<int> _songIndexesToRemove;
 
@@ -34,7 +34,7 @@
         public void HandleResponse_ResponseIsEmpty_ReturnsTrue()
         {
             var result = new UpdatePlaylistResultTests.UpdatePlaylistResultWrapper(
-                new SubsonicServiceConfiguration(), 1, _songIdsToAdd, _songIndexesToRemove);
+                new SubsonicServiceConfiguration(), "1", _songIdsToAdd, _songIndexesToRemove);
 
             result.CallHandleResponse(XDocument.Load(new StringReader(Data)));
 
@@ -50,9 +50,9 @@
         [TestInitialize]
         public void Setup()
         {
-            _songIdsToAdd = new List<int>();
+            _songIdsToAdd = new List<string>();
             _songIndexesToRemove = new List<int>();
-            _subject = new RenamePlaylistResultWrapper(new SubsonicServiceConfiguration(), 1, "test a");
+            _subject = new RenamePlaylistResultWrapper(new SubsonicServiceConfiguration(), "1", "test a");
         }
 
         [TestMethod]
@@ -67,7 +67,7 @@
         {
             #region Constructors and Destructors
 
-            public RenamePlaylistResultWrapper(ISubsonicServiceConfiguration configuration, int id, string name)
+            public RenamePlaylistResultWrapper(ISubsonicServiceConfiguration configuration, string id, string name)
                 : base(configuration, id, name)
             {
             }

--- a/Client.Common.Tests/Results/UpdatePlaylistResultTests.cs
+++ b/Client.Common.Tests/Results/UpdatePlaylistResultTests.cs
@@ -21,7 +21,7 @@
 
         #region Fields
 
-        private List<int> _songIdsToAdd;
+        private List<string> _songIdsToAdd;
 
         private List<int> _songIndexesToRemove;
 
@@ -35,7 +35,7 @@
         public void HandleResponse_ResponseIsEmpty_ReturnsTrue()
         {
             var result = new UpdatePlaylistResultWrapper(
-                new SubsonicServiceConfiguration(), 1, _songIdsToAdd, _songIndexesToRemove);
+                new SubsonicServiceConfiguration(), "1", _songIdsToAdd, _songIndexesToRemove);
 
             result.CallHandleResponse(XDocument.Load(new StringReader(Data)));
 
@@ -45,7 +45,7 @@
         [TestMethod]
         public void RequestUrlShouldBeCorrect()
         {
-            _songIdsToAdd.AddRange(Enumerable.Range(0, 2));
+            _songIdsToAdd.AddRange(new[] { "0", "1" });
             _songIndexesToRemove.AddRange(Enumerable.Range(2, 2));
 
             _subject.RequestUrl.Should()
@@ -55,10 +55,10 @@
         [TestInitialize]
         public void Setup()
         {
-            _songIdsToAdd = new List<int>();
+            _songIdsToAdd = new List<string>();
             _songIndexesToRemove = new List<int>();
             _subject = new UpdatePlaylistResultWrapper(
-                new SubsonicServiceConfiguration(), 1, _songIdsToAdd, _songIndexesToRemove);
+                new SubsonicServiceConfiguration(), "1", _songIdsToAdd, _songIndexesToRemove);
         }
 
         [TestMethod]
@@ -75,8 +75,8 @@
 
             public UpdatePlaylistResultWrapper(
                 ISubsonicServiceConfiguration configuration, 
-                int id, 
-                IEnumerable<int> songIdsToAdd, 
+                string id, 
+                IEnumerable<string> songIdsToAdd, 
                 IEnumerable<int> songIndexesToRemove)
                 : base(configuration, id, songIdsToAdd, songIndexesToRemove)
             {

--- a/Client.Common.Tests/Services/SubsonicServiceTests.cs
+++ b/Client.Common.Tests/Services/SubsonicServiceTests.cs
@@ -62,7 +62,7 @@
         [TestMethod]
         public void GetIndex_Always_ReturnsAGetIndexResult()
         {
-            var result = _subject.GetIndex(5);
+            var result = _subject.GetIndex("5");
 
             result.Should().BeOfType<GetIndexResult>();
         }
@@ -78,7 +78,7 @@
         [TestMethod]
         public void GetUriForFileWithId_Should_AccessTheStreamResource()
         {
-            var uriForFileWithId = _subject.GetUriForFileWithId(1);
+            var uriForFileWithId = _subject.GetUriForFileWithId("1");
 
             uriForFileWithId.ToString().Should().Contain("stream.view");
         }
@@ -86,7 +86,7 @@
         [TestMethod]
         public void GetUriForFileWithId_Should_ReturnAUriPoitingAtTheBaseUrl()
         {
-            var uriForFileWithId = _subject.GetUriForFileWithId(1);
+            var uriForFileWithId = _subject.GetUriForFileWithId("1");
 
             uriForFileWithId.ToString().Should().StartWith(_subject.Configuration.BaseUrl);
         }
@@ -94,7 +94,7 @@
         [TestMethod]
         public void GetUriForFileWithId_Should_SetTheUsernameAndPassword()
         {
-            var uriForFileWithId = _subject.GetUriForFileWithId(1);
+            var uriForFileWithId = _subject.GetUriForFileWithId("1");
 
             uriForFileWithId.ToString().Should().Contain("u=" + _subject.Configuration.Username);
             uriForFileWithId.ToString().Should().Contain("p=" + _subject.Configuration.EncodedPassword);
@@ -103,7 +103,7 @@
         [TestMethod]
         public void GetUriForFileWithId_Should_TreyToGetTheFileWithTheGivenId()
         {
-            var uriForFileWithId = _subject.GetUriForFileWithId(3);
+            var uriForFileWithId = _subject.GetUriForFileWithId("3");
 
             uriForFileWithId.ToString().Should().Contain("id=3");
         }
@@ -139,7 +139,7 @@
         [TestMethod]
         public void GetUriForVideoWithId_Always_ReturnsAUrlContainingTheConfigurationBaseUrl()
         {
-            var uriForVideoWithId = _subject.GetUriForVideoWithId(1);
+            var uriForVideoWithId = _subject.GetUriForVideoWithId("1");
 
             uriForVideoWithId.ToString().Should().StartWith(_subject.Configuration.BaseUrl);
         }
@@ -147,7 +147,7 @@
         [TestMethod]
         public void GetUriForVideoWithId_Always_ReturnsAUrlContainingTheGivenId()
         {
-            var uriForVideoWithId = _subject.GetUriForVideoWithId(3);
+            var uriForVideoWithId = _subject.GetUriForVideoWithId("3");
 
             uriForVideoWithId.ToString().Should().Contain("id=3");
         }
@@ -155,7 +155,7 @@
         [TestMethod]
         public void GetUriForVideoWithId_Always_ReturnsAUrlPointingToTheStreamResource()
         {
-            var uriForVideoWithId = _subject.GetUriForVideoWithId(1);
+            var uriForVideoWithId = _subject.GetUriForVideoWithId("1");
 
             uriForVideoWithId.ToString().Should().Contain("stream/stream.ts");
         }
@@ -163,7 +163,7 @@
         [TestMethod]
         public void GetUriForVideoWithId_Always_SpecifiesTheVideoShouldBeHls()
         {
-            var uriForVideoWithId = _subject.GetUriForVideoWithId(3);
+            var uriForVideoWithId = _subject.GetUriForVideoWithId("3");
 
             uriForVideoWithId.ToString().Should().Contain("hls=true");
         }
@@ -171,7 +171,7 @@
         [TestMethod]
         public void GetUriForVideoWithId_MaxBitRateGiven_ShouldSetMaxBitRate()
         {
-            var uriForVideoWithId = _subject.GetUriForVideoWithId(3, 20, 200);
+            var uriForVideoWithId = _subject.GetUriForVideoWithId("3", 20, 200);
 
             uriForVideoWithId.ToString().Should().Contain("maxBitRate=200");
         }
@@ -179,7 +179,7 @@
         [TestMethod]
         public void GetUriForVideoWithId_NoTimeOffsetGiven_ShouldSetTimeOffsetTo0()
         {
-            var uriForVideoWithId = _subject.GetUriForVideoWithId(3);
+            var uriForVideoWithId = _subject.GetUriForVideoWithId("3");
 
             uriForVideoWithId.ToString().Should().Contain("timeOffset=0");
         }
@@ -187,7 +187,7 @@
         [TestMethod]
         public void GetUriForVideoWithId_TimeOffsetGiven_ShouldSetTimeOffset()
         {
-            var uriForVideoWithId = _subject.GetUriForVideoWithId(3, 20);
+            var uriForVideoWithId = _subject.GetUriForVideoWithId("3", 20);
 
             uriForVideoWithId.ToString().Should().Contain("timeOffset=20");
         }

--- a/Client.Common/Client.Common.csproj
+++ b/Client.Common/Client.Common.csproj
@@ -214,6 +214,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\DataStructures\SubsonicService\SubsonicServiceConfigurationExtensions.cs" />
     <Compile Include="Services\WinRTWrappersService.cs" />
+    <Compile Include="Services\ICoverArtCacheService.cs" />
+    <Compile Include="Services\CoverArtCacheService.cs" />
+    <Compile Include="Services\RequestThrottler.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Caliburn.Micro, Version=1.5.2.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Client.Common/Models/IId.cs
+++ b/Client.Common/Models/IId.cs
@@ -4,7 +4,7 @@
     {
         #region Public Properties
 
-        int Id { get; }
+        string Id { get; }
 
         #endregion
     }

--- a/Client.Common/Models/Subsonic/Album.cs
+++ b/Client.Common/Models/Subsonic/Album.cs
@@ -22,7 +22,7 @@
         public string Artist { get; set; }
 
         [XmlAttribute("artistId")]
-        public int ArtistId { get; set; }
+        public string ArtistId { get; set; }
 
         [XmlAttribute("songCount")]
         public int SongCount { get; set; }

--- a/Client.Common/Models/Subsonic/MusicDirectoryChild.cs
+++ b/Client.Common/Models/Subsonic/MusicDirectoryChild.cs
@@ -38,7 +38,7 @@
         }
 
         [XmlAttribute("parent")]
-        public int Parent { get; set; }
+        public string Parent { get; set; }
 
         [XmlAttribute("title")]
         public string Title { get; set; }

--- a/Client.Common/Models/Subsonic/PlaylistEntry.cs
+++ b/Client.Common/Models/Subsonic/PlaylistEntry.cs
@@ -12,13 +12,13 @@
         public string Album { get; set; }
 
         [XmlAttribute("albumId")]
-        public int AlbumId { get; set; }
+        public string AlbumId { get; set; }
 
         [XmlAttribute("artist")]
         public string Artist { get; set; }
 
         [XmlAttribute("artistId")]
-        public int ArtistId { get; set; }
+        public string ArtistId { get; set; }
 
         [XmlAttribute("bitRate")]
         public int BitRate { get; set; }
@@ -47,7 +47,7 @@
         }
 
         [XmlAttribute("parent")]
-        public int ParentId { get; set; }
+        public string ParentId { get; set; }
 
         [XmlAttribute("title")]
         public string Title { get; set; }

--- a/Client.Common/Models/Subsonic/Song.cs
+++ b/Client.Common/Models/Subsonic/Song.cs
@@ -9,7 +9,7 @@
         #region Public Properties
 
         [XmlAttribute("artistId")]
-        public int ArtistId { get; set; }
+        public string ArtistId { get; set; }
 
         [XmlAttribute("songCount")]
         public int SongCount { get; set; }

--- a/Client.Common/Models/Subsonic/SubsonicModelBase.cs
+++ b/Client.Common/Models/Subsonic/SubsonicModelBase.cs
@@ -11,7 +11,7 @@
 
         [XmlAttribute("id")]
         [DataMember]
-        public int Id { get; set; }
+        public string Id { get; set; }
 
         [XmlAttribute("name")]
         [DataMember]

--- a/Client.Common/Results/CreatePlaylistResult.cs
+++ b/Client.Common/Results/CreatePlaylistResult.cs
@@ -9,7 +9,7 @@
     {
         #region Constructors and Destructors
 
-        public CreatePlaylistResult(ISubsonicServiceConfiguration configuration, string name, IEnumerable<int> songIds)
+        public CreatePlaylistResult(ISubsonicServiceConfiguration configuration, string name, IEnumerable<string> songIds)
             : base(configuration)
         {
             Name = name;
@@ -27,11 +27,11 @@
             get
             {
                 return base.RequestUrl + "&name=" + WebUtility.UrlEncode(Name)
-                       + SongIds.Aggregate(string.Empty, (result, entry) => result + "&songId=" + entry.ToString());
+                       + SongIds.Aggregate(string.Empty, (result, entry) => result + "&songId=" + entry);
             }
         }
 
-        public IEnumerable<int> SongIds { get; private set; }
+        public IEnumerable<string> SongIds { get; private set; }
 
         public override string ResourcePath
         {

--- a/Client.Common/Results/DeletePlaylistResult.cs
+++ b/Client.Common/Results/DeletePlaylistResult.cs
@@ -6,7 +6,7 @@
     {
         #region Constructors and Destructors
 
-        public DeletePlaylistResult(ISubsonicServiceConfiguration configuration, int id)
+        public DeletePlaylistResult(ISubsonicServiceConfiguration configuration, string id)
             : base(configuration)
         {
             Id = id;
@@ -16,7 +16,7 @@
 
         #region Public Properties
 
-        public int Id { get; private set; }
+        public string Id { get; private set; }
 
         public override string RequestUrl
         {

--- a/Client.Common/Results/GetAlbumResult.cs
+++ b/Client.Common/Results/GetAlbumResult.cs
@@ -9,7 +9,7 @@
     {
         #region Constructors and Destructors
 
-        public GetAlbumResult(ISubsonicServiceConfiguration configuration, int id)
+        public GetAlbumResult(ISubsonicServiceConfiguration configuration, string id)
             : base(configuration)
         {
             Id = id;
@@ -19,7 +19,7 @@
 
         #region Public Properties
 
-        public int Id { get; private set; }
+        public string Id { get; private set; }
 
         public override string RequestUrl
         {

--- a/Client.Common/Results/GetArtistsResult.cs
+++ b/Client.Common/Results/GetArtistsResult.cs
@@ -9,7 +9,7 @@
     {
         #region Constructors and Destructors
 
-        public GetArtistsResult(ISubsonicServiceConfiguration configuration, int id)
+        public GetArtistsResult(ISubsonicServiceConfiguration configuration, string id)
             : base(configuration)
         {
             Id = id;
@@ -19,7 +19,7 @@
 
         #region Public Properties
 
-        public int Id { get; private set; }
+        public string Id { get; private set; }
 
         public override string RequestUrl
         {

--- a/Client.Common/Results/GetMusicDirectoryResult.cs
+++ b/Client.Common/Results/GetMusicDirectoryResult.cs
@@ -9,13 +9,13 @@ namespace Client.Common.Results
     {
         #region Fields
 
-        private readonly int _id;
+        private readonly string _id;
 
         #endregion
 
         #region Constructors and Destructors
 
-        public GetMusicDirectoryResult(SubsonicServiceConfiguration configuration, int id)
+        public GetMusicDirectoryResult(SubsonicServiceConfiguration configuration, string id)
             : base(configuration)
         {
             _id = id;
@@ -25,7 +25,7 @@ namespace Client.Common.Results
 
         #region Public Properties
 
-        public int Id
+        public string Id
         {
             get
             {

--- a/Client.Common/Results/GetPlaylistResult.cs
+++ b/Client.Common/Results/GetPlaylistResult.cs
@@ -9,7 +9,7 @@
     {
         #region Constructors and Destructors
 
-        public GetPlaylistResult(ISubsonicServiceConfiguration configuration, int id)
+        public GetPlaylistResult(ISubsonicServiceConfiguration configuration, string id)
             : base(configuration)
         {
             Id = id;
@@ -19,7 +19,7 @@
 
         #region Public Properties
 
-        public int Id { get; private set; }
+        public string Id { get; private set; }
 
         public override string RequestUrl
         {

--- a/Client.Common/Results/GetSongResult.cs
+++ b/Client.Common/Results/GetSongResult.cs
@@ -9,7 +9,7 @@
     {
         #region Constructors and Destructors
 
-        public GetSongResult(ISubsonicServiceConfiguration configuration, int id)
+        public GetSongResult(ISubsonicServiceConfiguration configuration, string id)
             : base(configuration)
         {
             Id = id;
@@ -19,7 +19,7 @@
 
         #region Public Properties
 
-        public int Id { get; private set; }
+        public string Id { get; private set; }
 
         public override string RequestUrl
         {

--- a/Client.Common/Results/ICreatePlaylistResult.cs
+++ b/Client.Common/Results/ICreatePlaylistResult.cs
@@ -8,7 +8,7 @@
 
         string Name { get; }
 
-        IEnumerable<int> SongIds { get; }
+        IEnumerable<string> SongIds { get; }
 
         #endregion
     }

--- a/Client.Common/Results/IDeletePlaylistResult.cs
+++ b/Client.Common/Results/IDeletePlaylistResult.cs
@@ -4,7 +4,7 @@
     {
         #region Public Properties
 
-        int Id { get; }
+        string Id { get; }
 
         #endregion
     }

--- a/Client.Common/Results/IGetPlaylistResult.cs
+++ b/Client.Common/Results/IGetPlaylistResult.cs
@@ -6,7 +6,7 @@
     {
         #region Public Properties
 
-        int Id { get; }
+        string Id { get; }
 
         #endregion
     }

--- a/Client.Common/Results/IRenamePlaylistResult.cs
+++ b/Client.Common/Results/IRenamePlaylistResult.cs
@@ -4,7 +4,7 @@
     {
         #region Public Properties
 
-        int Id { get; }
+        string Id { get; }
 
         string Name { get; }
 

--- a/Client.Common/Results/IUpdatePlaylistResult.cs
+++ b/Client.Common/Results/IUpdatePlaylistResult.cs
@@ -6,9 +6,9 @@
     {
         #region Public Properties
 
-        int Id { get; }
+        string Id { get; }
 
-        IEnumerable<int> SongIdsToAdd { get; }
+        IEnumerable<string> SongIdsToAdd { get; }
 
         IEnumerable<int> SongIndexesToRemove { get; }
 

--- a/Client.Common/Results/RenamePlaylistResult.cs
+++ b/Client.Common/Results/RenamePlaylistResult.cs
@@ -8,7 +8,7 @@
     {
         #region Constructors and Destructors
 
-        public RenamePlaylistResult(ISubsonicServiceConfiguration configuration, int id, string name)
+        public RenamePlaylistResult(ISubsonicServiceConfiguration configuration, string id, string name)
             : base(configuration)
         {
             Id = id;
@@ -19,7 +19,7 @@
 
         #region Public Properties
 
-        public int Id { get; private set; }
+        public string Id { get; private set; }
 
         public string Name { get; private set; }
 

--- a/Client.Common/Results/UpdatePlaylistResult.cs
+++ b/Client.Common/Results/UpdatePlaylistResult.cs
@@ -10,8 +10,8 @@
 
         public UpdatePlaylistResult(
             ISubsonicServiceConfiguration configuration, 
-            int id, 
-            IEnumerable<int> songIdsToAdd, 
+            string id, 
+            IEnumerable<string> songIdsToAdd, 
             IEnumerable<int> songIndexesToRemove)
             : base(configuration)
         {
@@ -24,7 +24,7 @@
 
         #region Public Properties
 
-        public int Id { get; private set; }
+        public string Id { get; private set; }
 
         public override string RequestUrl
         {
@@ -32,13 +32,13 @@
             {
                 return base.RequestUrl + "&playlistId=" + Id
                        + SongIdsToAdd.Aggregate(
-                           string.Empty, (result, entry) => result + "&songIdToAdd=" + entry.ToString())
+                           string.Empty, (result, entry) => result + "&songIdToAdd=" + entry)
                        + SongIndexesToRemove.Aggregate(
                            string.Empty, (result, entry) => result + "&songIndexToRemove=" + entry.ToString());
             }
         }
 
-        public IEnumerable<int> SongIdsToAdd { get; private set; }
+        public IEnumerable<string> SongIdsToAdd { get; private set; }
 
         public IEnumerable<int> SongIndexesToRemove { get; private set; }
 

--- a/Client.Common/Services/CoverArtCacheService.cs
+++ b/Client.Common/Services/CoverArtCacheService.cs
@@ -1,0 +1,170 @@
+namespace Client.Common.Services
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
+    using Windows.Storage;
+    using Windows.UI.Xaml.Media.Imaging;
+
+    /// <summary>
+    /// 封面图片缓存服务实现
+    /// </summary>
+    public class CoverArtCacheService : ICoverArtCacheService
+    {
+        private const string CacheFolderName = "CoverArtCache";
+        private const int DefaultExpirationDays = 7;
+        
+        private static readonly HttpClient HttpClient = new HttpClient();
+        private StorageFolder _cacheFolder;
+
+        /// <summary>
+        /// 获取缓存的封面图片
+        /// </summary>
+        public async Task<BitmapImage> GetCoverArtAsync(string coverArtUrl)
+        {
+            if (string.IsNullOrEmpty(coverArtUrl) || coverArtUrl.StartsWith("/Assets"))
+            {
+                // 返回占位符图片
+                return new BitmapImage(new Uri("ms-appx://" + (coverArtUrl ?? "/Assets/CoverArtPlaceholder.jpg")));
+            }
+
+            var cacheKey = GetCacheKey(coverArtUrl);
+            var cacheFolder = await GetCacheFolderAsync();
+
+            try
+            {
+                // 尝试从缓存获取
+                var cachedFile = await cacheFolder.TryGetItemAsync(cacheKey + ".jpg") as StorageFile;
+                if (cachedFile != null)
+                {
+                    var bitmap = new BitmapImage();
+                    using (var stream = await cachedFile.OpenReadAsync())
+                    {
+                        await bitmap.SetSourceAsync(stream);
+                    }
+                    return bitmap;
+                }
+
+                // 缓存未命中，通过限流阀下载
+                return await RequestThrottler.ExecuteAsync(async () =>
+                {
+                    var imageBytes = await HttpClient.GetByteArrayAsync(coverArtUrl);
+                    
+                    // 保存到缓存
+                    var file = await cacheFolder.CreateFileAsync(cacheKey + ".jpg", CreationCollisionOption.ReplaceExisting);
+                    await FileIO.WriteBytesAsync(file, imageBytes);
+
+                    var bitmap = new BitmapImage();
+                    using (var stream = new MemoryStream(imageBytes))
+                    {
+                        await bitmap.SetSourceAsync(stream.AsRandomAccessStream());
+                    }
+                    return bitmap;
+                });
+            }
+            catch (Exception)
+            {
+                // 下载失败，返回占位符
+                return new BitmapImage(new Uri("ms-appx:///Assets/CoverArtPlaceholder.jpg"));
+            }
+        }
+
+        /// <summary>
+        /// 获取缓存大小
+        /// </summary>
+        public async Task<ulong> GetCacheSizeAsync()
+        {
+            var cacheFolder = await GetCacheFolderAsync();
+            var files = await cacheFolder.GetFilesAsync();
+            
+            ulong totalSize = 0;
+            foreach (var file in files)
+            {
+                var props = await file.GetBasicPropertiesAsync();
+                totalSize += props.Size;
+            }
+            return totalSize;
+        }
+
+        /// <summary>
+        /// 清理所有缓存
+        /// </summary>
+        public async Task ClearAllCacheAsync()
+        {
+            var cacheFolder = await GetCacheFolderAsync();
+            var files = await cacheFolder.GetFilesAsync();
+            
+            foreach (var file in files)
+            {
+                await file.DeleteAsync();
+            }
+        }
+
+        /// <summary>
+        /// 清理过期缓存
+        /// </summary>
+        public async Task CleanExpiredCacheAsync(int expirationDays = DefaultExpirationDays)
+        {
+            var cacheFolder = await GetCacheFolderAsync();
+            var files = await cacheFolder.GetFilesAsync();
+            var expirationDate = DateTimeOffset.Now.AddDays(-expirationDays);
+
+            foreach (var file in files)
+            {
+                var props = await file.GetBasicPropertiesAsync();
+                if (props.DateModified < expirationDate)
+                {
+                    await file.DeleteAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// 从 URL 提取缓存键
+        /// 使用 id 和 size 参数，包含 Navidrome 的 _t 时间戳参数用于 Cache Busting
+        /// </summary>
+        private string GetCacheKey(string url)
+        {
+            var idMatch = Regex.Match(url, @"[&?]id=([^&]+)");
+            var sizeMatch = Regex.Match(url, @"[&?]size=([^&]+)");
+            var timestampMatch = Regex.Match(url, @"[&?]_t=([^&]+)");
+
+            var id = idMatch.Success ? idMatch.Groups[1].Value : "unknown";
+            var size = sizeMatch.Success ? sizeMatch.Groups[1].Value : "default";
+            var timestamp = timestampMatch.Success ? "_" + timestampMatch.Groups[1].Value : "";
+
+            // 清理非法文件名字符
+            var key = $"{id}_{size}{timestamp}";
+            return Regex.Replace(key, @"[<>:""/\\|?*]", "_");
+        }
+
+        private async Task<StorageFolder> GetCacheFolderAsync()
+        {
+            if (_cacheFolder == null)
+            {
+                _cacheFolder = await ApplicationData.Current.LocalFolder.CreateFolderAsync(
+                    CacheFolderName, CreationCollisionOption.OpenIfExists);
+            }
+            return _cacheFolder;
+        }
+
+        /// <summary>
+        /// 格式化文件大小显示
+        /// </summary>
+        public static string FormatFileSize(ulong bytes)
+        {
+            string[] sizes = { "B", "KB", "MB", "GB" };
+            double len = bytes;
+            int order = 0;
+            while (len >= 1024 && order < sizes.Length - 1)
+            {
+                order++;
+                len = len / 1024;
+            }
+            return $"{len:0.##} {sizes[order]}";
+        }
+    }
+}

--- a/Client.Common/Services/DataStructures/SubsonicService/ImageType.cs
+++ b/Client.Common/Services/DataStructures/SubsonicService/ImageType.cs
@@ -2,8 +2,8 @@
 {
     public enum ImageType
     {
-        Thumbnail = 150, 
+        Thumbnail = 100,  // 降低缩略图尺寸以减少带宽
 
-        Original = 500
+        Original = 300    // 降低原图尺寸
     }
 }

--- a/Client.Common/Services/ICoverArtCacheService.cs
+++ b/Client.Common/Services/ICoverArtCacheService.cs
@@ -1,0 +1,35 @@
+namespace Client.Common.Services
+{
+    using System;
+    using System.IO;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Windows.Storage;
+    using Windows.UI.Xaml.Media.Imaging;
+
+    /// <summary>
+    /// 封面图片缓存服务接口
+    /// </summary>
+    public interface ICoverArtCacheService
+    {
+        /// <summary>
+        /// 获取缓存的封面图片，如果不存在则下载并缓存
+        /// </summary>
+        Task<BitmapImage> GetCoverArtAsync(string coverArtUrl);
+
+        /// <summary>
+        /// 获取缓存大小（字节）
+        /// </summary>
+        Task<ulong> GetCacheSizeAsync();
+
+        /// <summary>
+        /// 清理所有缓存
+        /// </summary>
+        Task ClearAllCacheAsync();
+
+        /// <summary>
+        /// 清理过期缓存（超过指定天数）
+        /// </summary>
+        Task CleanExpiredCacheAsync(int expirationDays = 7);
+    }
+}

--- a/Client.Common/Services/ISubsonicService.cs
+++ b/Client.Common/Services/ISubsonicService.cs
@@ -13,35 +13,35 @@ namespace Client.Common.Services
 
         SubsonicServiceConfiguration Configuration { get; set; }
 
-        Func<string, IEnumerable<int>, ICreatePlaylistResult> CreatePlaylist { get; set; }
+        Func<string, IEnumerable<string>, ICreatePlaylistResult> CreatePlaylist { get; set; }
 
-        Func<int, IDeletePlaylistResult> DeletePlaylist { get; set; }
+        Func<string, IDeletePlaylistResult> DeletePlaylist { get; set; }
 
-        Func<int, IGetAlbumResult> GetAlbum { get; set; }
+        Func<string, IGetAlbumResult> GetAlbum { get; set; }
 
         Func<IGetAllPlaylistsResult> GetAllPlaylists { get; set; }
 
-        Func<int, IGetArtistResult> GetArtist { get; set; }
+        Func<string, IGetArtistResult> GetArtist { get; set; }
 
-        Func<int, IGetIndexResult> GetIndex { get; set; }
+        Func<string, IGetIndexResult> GetIndex { get; set; }
 
-        Func<int, IGetMusicDirectoryResult> GetMusicDirectory { get; set; }
+        Func<string, IGetMusicDirectoryResult> GetMusicDirectory { get; set; }
 
         Func<IGetRootResult> GetMusicFolders { get; set; }
 
-        Func<int, IGetPlaylistResult> GetPlaylist { get; set; }
+        Func<string, IGetPlaylistResult> GetPlaylist { get; set; }
 
-        Func<int, IGetSongResult> GetSong { get; set; }
+        Func<string, IGetSongResult> GetSong { get; set; }
 
         bool HasValidSubsonicUrl { get; }
 
         Func<IPingResult> Ping { get; set; }
 
-        Func<int, string, IRenamePlaylistResult> RenamePlaylist { get; set; }
+        Func<string, string, IRenamePlaylistResult> RenamePlaylist { get; set; }
 
         Func<string, ISearchResult> Search { get; set; }
 
-        Func<int, IEnumerable<int>, IEnumerable<int>, IUpdatePlaylistResult> UpdatePlaylist { get; set; }
+        Func<string, IEnumerable<string>, IEnumerable<int>, IUpdatePlaylistResult> UpdatePlaylist { get; set; }
 
         Func<int, IGetRandomSongsResult> GetRandomSongs { get; set; }
 
@@ -53,11 +53,11 @@ namespace Client.Common.Services
 
         string GetCoverArtForId(string coverArt, ImageType imageType);
 
-        Uri GetUriForFileWithId(int id);
+        Uri GetUriForFileWithId(string id);
 
         Uri GetUriForVideoStartingAt(Uri source, double totalSeconds);
 
-        Uri GetUriForVideoWithId(int id, int timeOffset = 0, int maxBitRate = 0);
+        Uri GetUriForVideoWithId(string id, int timeOffset = 0, int maxBitRate = 0);
 
         #endregion
     }

--- a/Client.Common/Services/RequestThrottler.cs
+++ b/Client.Common/Services/RequestThrottler.cs
@@ -1,0 +1,54 @@
+namespace Client.Common.Services
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// 全局请求限流器，使用 SemaphoreSlim 限制并发请求数
+    /// </summary>
+    public static class RequestThrottler
+    {
+        // 最大并发请求数
+        private const int MaxConcurrentRequests = 3;
+        
+        private static readonly SemaphoreSlim Semaphore = new SemaphoreSlim(MaxConcurrentRequests, MaxConcurrentRequests);
+
+        /// <summary>
+        /// 在限流控制下执行异步操作（有返回值）
+        /// </summary>
+        public static async Task<T> ExecuteAsync<T>(Func<Task<T>> action)
+        {
+            await Semaphore.WaitAsync();
+            try
+            {
+                return await action();
+            }
+            finally
+            {
+                Semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// 在限流控制下执行异步操作（无返回值）
+        /// </summary>
+        public static async Task ExecuteAsync(Func<Task> action)
+        {
+            await Semaphore.WaitAsync();
+            try
+            {
+                await action();
+            }
+            finally
+            {
+                Semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// 获取当前可用的请求槽位数
+        /// </summary>
+        public static int AvailableSlots => Semaphore.CurrentCount;
+    }
+}

--- a/Client.Common/Services/SubsonicService.cs
+++ b/Client.Common/Services/SubsonicService.cs
@@ -61,25 +61,25 @@
             }
         }
 
-        public Func<string, IEnumerable<int>, ICreatePlaylistResult> CreatePlaylist { get; set; }
+        public Func<string, IEnumerable<string>, ICreatePlaylistResult> CreatePlaylist { get; set; }
 
-        public Func<int, IDeletePlaylistResult> DeletePlaylist { get; set; }
+        public Func<string, IDeletePlaylistResult> DeletePlaylist { get; set; }
 
-        public Func<int, IGetAlbumResult> GetAlbum { get; set; }
+        public Func<string, IGetAlbumResult> GetAlbum { get; set; }
 
         public Func<IGetAllPlaylistsResult> GetAllPlaylists { get; set; }
 
-        public Func<int, IGetArtistResult> GetArtist { get; set; }
+        public Func<string, IGetArtistResult> GetArtist { get; set; }
 
-        public Func<int, IGetIndexResult> GetIndex { get; set; }
+        public Func<string, IGetIndexResult> GetIndex { get; set; }
 
-        public Func<int, IGetMusicDirectoryResult> GetMusicDirectory { get; set; }
+        public Func<string, IGetMusicDirectoryResult> GetMusicDirectory { get; set; }
 
         public Func<IGetRootResult> GetMusicFolders { get; set; }
 
-        public Func<int, IGetPlaylistResult> GetPlaylist { get; set; }
+        public Func<string, IGetPlaylistResult> GetPlaylist { get; set; }
 
-        public Func<int, IGetSongResult> GetSong { get; set; }
+        public Func<string, IGetSongResult> GetSong { get; set; }
 
         public virtual bool HasValidSubsonicUrl
         {
@@ -91,11 +91,11 @@
 
         public Func<IPingResult> Ping { get; set; }
 
-        public Func<int, string, IRenamePlaylistResult> RenamePlaylist { get; set; }
+        public Func<string, string, IRenamePlaylistResult> RenamePlaylist { get; set; }
 
         public Func<string, ISearchResult> Search { get; set; }
 
-        public Func<int, IEnumerable<int>, IEnumerable<int>, IUpdatePlaylistResult> UpdatePlaylist { get; set; }
+        public Func<string, IEnumerable<string>, IEnumerable<int>, IUpdatePlaylistResult> UpdatePlaylist { get; set; }
 
         public Func<int, IGetRandomSongsResult> GetRandomSongs { get; set; }
 
@@ -130,7 +130,7 @@
             return result;
         }
 
-        public virtual Uri GetUriForFileWithId(int id)
+        public virtual Uri GetUriForFileWithId(string id)
         {
             return
                 new Uri(
@@ -151,7 +151,7 @@
             return new Uri(regex.Replace(uriString, regeExFormat));
         }
 
-        public virtual Uri GetUriForVideoWithId(int id, int timeOffset = 0, int maxBitRate = 0)
+        public virtual Uri GetUriForVideoWithId(string id, int timeOffset = 0, int maxBitRate = 0)
         {
             var uriString = string.Format(
                 "{0}stream/stream.ts?id={1}&hls=true&timeOffset={2}", _configuration.BaseUrl, id, timeOffset);
@@ -167,17 +167,17 @@
 
         #region Methods
 
-        private ICreatePlaylistResult CreatePlaylistImpl(string name, IEnumerable<int> songIds)
+        private ICreatePlaylistResult CreatePlaylistImpl(string name, IEnumerable<string> songIds)
         {
             return new CreatePlaylistResult(Configuration, name, songIds);
         }
 
-        private IDeletePlaylistResult DeletePlaylistImpl(int id)
+        private IDeletePlaylistResult DeletePlaylistImpl(string id)
         {
             return new DeletePlaylistResult(Configuration, id);
         }
 
-        private IGetAlbumResult GetAlbumImpl(int id)
+        private IGetAlbumResult GetAlbumImpl(string id)
         {
             return new GetAlbumResult(_configuration, id);
         }
@@ -187,17 +187,17 @@
             return new GetAllPlaylistsResult(_configuration);
         }
 
-        private IGetArtistResult GetArtistImpl(int id)
+        private IGetArtistResult GetArtistImpl(string id)
         {
             return new GetArtistsResult(_configuration, id);
         }
 
-        private IGetIndexResult GetIndexImpl(int musicFolderId)
+        private IGetIndexResult GetIndexImpl(string musicFolderId)
         {
             return new GetIndexResult(_configuration, musicFolderId);
         }
 
-        private IGetMusicDirectoryResult GetMusicDirectoryImpl(int id)
+        private IGetMusicDirectoryResult GetMusicDirectoryImpl(string id)
         {
             return new GetMusicDirectoryResult(_configuration, id);
         }
@@ -207,12 +207,12 @@
             return new GetRootResult(_configuration);
         }
 
-        private IGetPlaylistResult GetPlaylistImpl(int id)
+        private IGetPlaylistResult GetPlaylistImpl(string id)
         {
             return new GetPlaylistResult(_configuration, id);
         }
 
-        private IGetSongResult GetSongImpl(int id)
+        private IGetSongResult GetSongImpl(string id)
         {
             return new GetSongResult(_configuration, id);
         }
@@ -222,7 +222,7 @@
             return new PingResult(Configuration);
         }
 
-        private IRenamePlaylistResult RenamePlaylistImpl(int id, string name)
+        private IRenamePlaylistResult RenamePlaylistImpl(string id, string name)
         {
             return new RenamePlaylistResult(Configuration, id, name);
         }
@@ -233,7 +233,7 @@
         }
 
         private IUpdatePlaylistResult UpdatePlaylistResultImpl(
-            int id, IEnumerable<int> songIdsToAdd, IEnumerable<int> songIndexesToRemove)
+            string id, IEnumerable<string> songIdsToAdd, IEnumerable<int> songIndexesToRemove)
         {
             return new UpdatePlaylistResult(Configuration, id, songIdsToAdd, songIndexesToRemove);
         }

--- a/Client.Tests/Framework/ViewModel/DetailViewModelBaseTests.cs
+++ b/Client.Tests/Framework/ViewModel/DetailViewModelBaseTests.cs
@@ -6,7 +6,7 @@
 
     [TestClass]
     public abstract class DetailViewModelBaseTests<TSubsonicModel, TViewModel> :
-        CollectionViewModelBaseTests<TViewModel, int>
+        CollectionViewModelBaseTests<TViewModel, string>
         where TViewModel : IDetailViewModel<TSubsonicModel>, new() where TSubsonicModel : ISubsonicModel
     {
     }

--- a/Client.Tests/Mocks/MockCreatePlaylistResult.cs
+++ b/Client.Tests/Mocks/MockCreatePlaylistResult.cs
@@ -10,7 +10,7 @@
 
         public string Name { get; private set; }
 
-        public IEnumerable<int> SongIds { get; private set; }
+        public IEnumerable<string> SongIds { get; private set; }
 
         #endregion
     }

--- a/Client.Tests/Mocks/MockGetPlaylistResult.cs
+++ b/Client.Tests/Mocks/MockGetPlaylistResult.cs
@@ -8,7 +8,7 @@
     {
         #region Public Properties
 
-        public int Id { get; private set; }
+        public string Id { get; private set; }
 
         #endregion
     }

--- a/Client.Tests/Mocks/MockRenamePlaylistResult.cs
+++ b/Client.Tests/Mocks/MockRenamePlaylistResult.cs
@@ -7,7 +7,7 @@
     {
         #region Public Properties
 
-        public int Id { get; private set; }
+        public string Id { get; private set; }
 
         public string Name { get; private set; }
 

--- a/Client.Tests/Mocks/MockSubsonicModel.cs
+++ b/Client.Tests/Mocks/MockSubsonicModel.cs
@@ -9,7 +9,7 @@
 
         public string CoverArt { get; set; }
 
-        public int Id { get; set; }
+        public string Id { get; set; }
 
         public string Name { get; set; }
 

--- a/Client.Tests/Mocks/MockUpdatePlaylistResult.cs
+++ b/Client.Tests/Mocks/MockUpdatePlaylistResult.cs
@@ -8,9 +8,9 @@
     {
         #region Public Properties
 
-        public int Id { get; private set; }
+        public string Id { get; private set; }
 
-        public IEnumerable<int> SongIdsToAdd { get; private set; }
+        public IEnumerable<string> SongIdsToAdd { get; private set; }
 
         public IEnumerable<int> SongIndexesToRemove { get; private set; }
 

--- a/Client/Album/AlbumViewModel.cs
+++ b/Client/Album/AlbumViewModel.cs
@@ -15,7 +15,7 @@
             return result.Songs;
         }
 
-        protected override IServiceResultBase<Album> GetResult(int id)
+        protected override IServiceResultBase<Album> GetResult(string id)
         {
             return SubsonicService.GetAlbum(id);
         }

--- a/Client/App.xaml
+++ b/Client/App.xaml
@@ -2,7 +2,8 @@
     x:Class="Subsonic8.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:framework="using:Subsonic8.Framework">
+    xmlns:framework="using:Subsonic8.Framework"
+    xmlns:converters="using:Subsonic8.Framework.Converters">
 
     <Application.Resources>
         <ResourceDictionary>
@@ -16,6 +17,8 @@
                 <ResourceDictionary Source="Common/CustomStyles.xaml" />
                 <ResourceDictionary Source="Common/SnappedStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <converters:CoverArtConverter x:Key="CoverArtConverter" />
 
             <Color x:Key="MetroBlue">#FF3C557D</Color>
 

--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -44,9 +44,20 @@
             Kernel.Load<ClientModule>();
         }
 
-        protected override void OnLaunched(LaunchActivatedEventArgs args)
+        protected override async void OnLaunched(LaunchActivatedEventArgs args)
         {
             StartApplication();
+            
+            // 启动后清理过期缓存（7天前）- 延迟执行避免阻塞启动
+            try
+            {
+                var cacheService = Kernel.Get<ICoverArtCacheService>();
+                await cacheService.CleanExpiredCacheAsync(7);
+            }
+            catch
+            {
+                // 缓存清理失败不影响应用启动
+            }
         }
 
         protected override void OnSearchActivated(SearchActivatedEventArgs args)

--- a/Client/Artist/ArtistViewModel.cs
+++ b/Client/Artist/ArtistViewModel.cs
@@ -26,7 +26,7 @@
             return result.Albums;
         }
 
-        protected override IServiceResultBase<ExpandedArtist> GetResult(int id)
+        protected override IServiceResultBase<ExpandedArtist> GetResult(string id)
         {
             return SubsonicService.GetArtist(id);
         }

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Converters\PlaybackStateToVisibilityConverter.cs" />
     <Compile Include="Converters\PlayingStateToVisibilityConverter.cs" />
     <Compile Include="Converters\StringToVisibilityConverter.cs" />
+    <Compile Include="Framework\Converters\CoverArtConverter.cs" />
     <Compile Include="EchoNestCredentials.cs" />
     <Compile Include="ErrorDialog\ErrorDialogViewModelStrings.cs">
       <AutoGen>True</AutoGen>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -438,7 +438,6 @@
     <Content Include="Assets\Logo.png" />
     <Content Include="Assets\subsonic.png" />
     <Content Include="Assets\WideLogo.png" />
-    <None Include="Package.StoreAssociation.xml" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/Client/ClientModule.cs
+++ b/Client/ClientModule.cs
@@ -36,6 +36,7 @@
             Singletons.Add<INotificationsHelper, NotificationsHelper>();
             Singletons.Add<IConfigurationProvider, LastFmConfigurationProvider>();
             Singletons.Add<SubEchoNest.IConfigurationProvider, EchoNestConfigurationProvider>();
+            // ICoverArtCacheService 由 SubsonicCommonModule 的 ServiceConvention 自动注册
         }
 
         #endregion

--- a/Client/Framework/Converters/CoverArtConverter.cs
+++ b/Client/Framework/Converters/CoverArtConverter.cs
@@ -1,0 +1,118 @@
+namespace Subsonic8.Framework.Converters
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Threading.Tasks;
+    using Caliburn.Micro;
+    using Client.Common.Services;
+    using Windows.UI.Xaml;
+    using Windows.UI.Xaml.Data;
+    using Windows.UI.Xaml.Media.Imaging;
+
+    /// <summary>
+    /// 将封面图片 URL 转换为 BitmapImage，通过缓存服务加载实现限流
+    /// </summary>
+    public class CoverArtConverter : IValueConverter
+    {
+        // 用于跟踪正在加载的图片，避免重复请求
+        private static readonly ConcurrentDictionary<string, Task<BitmapImage>> LoadingTasks = 
+            new ConcurrentDictionary<string, Task<BitmapImage>>();
+
+        private static ICoverArtCacheService _cacheService;
+
+        private static ICoverArtCacheService CacheService
+        {
+            get
+            {
+                if (_cacheService == null)
+                {
+                    try
+                    {
+                        _cacheService = IoC.Get<ICoverArtCacheService>();
+                    }
+                    catch
+                    {
+                        // DI 未就绪时返回 null
+                    }
+                }
+                return _cacheService;
+            }
+        }
+
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            var url = value as string;
+            
+            // 空 URL 或占位符路径
+            if (string.IsNullOrEmpty(url))
+            {
+                return new BitmapImage(new Uri("ms-appx:///Assets/CoverArtPlaceholder.jpg"));
+            }
+
+            // 本地资源路径
+            if (url.StartsWith("/Assets") || url.StartsWith("ms-appx"))
+            {
+                return new BitmapImage(new Uri(url.StartsWith("ms-appx") ? url : "ms-appx://" + url));
+            }
+
+            // 通过缓存服务异步加载
+            var bitmap = new BitmapImage();
+            
+            // 启动异步加载任务
+            var _ = LoadImageAsync(url, bitmap);
+            
+            return bitmap;
+        }
+
+        private async Task LoadImageAsync(string url, BitmapImage targetBitmap)
+        {
+            try
+            {
+                if (CacheService == null)
+                {
+                    // 缓存服务不可用，直接设置 URI
+                    targetBitmap.UriSource = new Uri(url);
+                    return;
+                }
+
+                // 使用缓存服务加载（内部已集成限流）
+                var cachedBitmap = await CacheService.GetCoverArtAsync(url);
+                
+                // 由于 BitmapImage 创建后无法直接复制，需要在 UI 线程更新
+                await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
+                    Windows.UI.Core.CoreDispatcherPriority.Normal,
+                    () =>
+                    {
+                        try
+                        {
+                            // 直接设置 URI，因为缓存服务已经下载完成
+                            targetBitmap.UriSource = new Uri(url);
+                        }
+                        catch
+                        {
+                            // 设置失败时使用占位符
+                        }
+                    });
+            }
+            catch
+            {
+                // 加载失败，使用占位符
+                try
+                {
+                    await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
+                        Windows.UI.Core.CoreDispatcherPriority.Normal,
+                        () =>
+                        {
+                            targetBitmap.UriSource = new Uri("ms-appx:///Assets/CoverArtPlaceholder.jpg");
+                        });
+                }
+                catch { }
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Client/Framework/ViewModel/DetailViewModelBase.cs
+++ b/Client/Framework/ViewModel/DetailViewModelBase.cs
@@ -2,7 +2,7 @@
 {
     using Client.Common.Models;
 
-    public abstract class DetailViewModelBase<T> : CollectionViewModelBase<int, T>, IDetailViewModel<T>
+    public abstract class DetailViewModelBase<T> : CollectionViewModelBase<string, T>, IDetailViewModel<T>
         where T : class, ISubsonicModel
     {
         #region Fields

--- a/Client/Framework/ViewModel/IDetailViewModel.cs
+++ b/Client/Framework/ViewModel/IDetailViewModel.cs
@@ -2,7 +2,7 @@ namespace Subsonic8.Framework.ViewModel
 {
     using Client.Common.Models;
 
-    public interface IDetailViewModel<T> : ICollectionViewModel<int>
+    public interface IDetailViewModel<T> : ICollectionViewModel<string>
         where T : ISubsonicModel
     {
         #region Public Properties

--- a/Client/Index/IndexViewModel.cs
+++ b/Client/Index/IndexViewModel.cs
@@ -23,7 +23,7 @@
 
         #region Methods
 
-        protected override async Task AfterPopulate(int id)
+        protected override async Task AfterPopulate(string id)
         {
             var result = SubsonicService.GetMusicFolders();
             await result.WithErrorHandler(ErrorDialogViewModel).OnSuccess(r => SetIndexName(r, id)).Execute();
@@ -34,15 +34,26 @@
             return result.Artists;
         }
 
-        protected override IServiceResultBase<IndexItem> GetResult(int id)
+        protected override IServiceResultBase<IndexItem> GetResult(string id)
         {
             return SubsonicService.GetIndex(id);
         }
 
-        private void SetIndexName(IEnumerable<MusicFolder> musicFolders, int id)
+        private void SetIndexName(IEnumerable<MusicFolder> musicFolders, string id)
         {
-            var rootFolder = musicFolders.First(f => f.Id == id);
-            Item.Name = rootFolder != null ? rootFolder.Name : "Unknown";
+            if (Item == null)
+            {
+                return;
+            }
+
+            if (musicFolders == null || !musicFolders.Any())
+            {
+                Item.Name = "Music";
+                return;
+            }
+
+            var rootFolder = musicFolders.FirstOrDefault(f => f != null && f.Id == id);
+            Item.Name = rootFolder?.Name ?? "Music";
         }
 
         #endregion

--- a/Client/MenuItem/MenuItemView.xaml
+++ b/Client/MenuItem/MenuItemView.xaml
@@ -13,7 +13,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Image Source="{Binding CoverArt}" Margin="0,0,0,0" Width="150" Height="150"/>
+        <Image Source="{Binding CoverArt, Converter={StaticResource CoverArtConverter}}" Margin="0,0,0,0" Width="150" Height="150"/>
         <StackPanel Grid.Row="1" Margin="0" VerticalAlignment="Center">
             <TextBlock Text="{Binding Title}" Style="{StaticResource BodyTextStyle}" TextWrapping="NoWrap" />
             <TextBlock Text="{Binding Subtitle}" Style="{StaticResource BodyTextStyle}" 

--- a/Client/MusicDirectory/MusicDirectoryViewModel.cs
+++ b/Client/MusicDirectory/MusicDirectoryViewModel.cs
@@ -24,7 +24,7 @@
             return result.Children;
         }
 
-        protected override IServiceResultBase<MusicDirectory> GetResult(int id)
+        protected override IServiceResultBase<MusicDirectory> GetResult(string id)
         {
             return SubsonicService.GetMusicDirectory(id);
         }

--- a/Client/Playback/Playback/Audio.xaml
+++ b/Client/Playback/Playback/Audio.xaml
@@ -19,7 +19,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Image Source="{Binding CoverArt}" Style="{StaticResource PlaybackBigCoverArtStyle}" effects:Tilt.IsTiltEnabled="True" />
+        <Image Source="{Binding CoverArt, Converter={StaticResource CoverArtConverter}}" Style="{StaticResource PlaybackBigCoverArtStyle}" effects:Tilt.IsTiltEnabled="True" />
         <playback:ProgressIndicatorView Grid.Row="1" cal:Bind.Model="{Binding ProgressIndicatorViewModel}" />
         <StackPanel Grid.Row="2" Style="{StaticResource PlaybackControlsPanelStyle}"
                     Visibility="{Binding Path=PlaybackControlsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">

--- a/Client/Playback/Playback/Filter.xaml
+++ b/Client/Playback/Playback/Filter.xaml
@@ -14,7 +14,7 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Image Source="{Binding CoverArt}" Style="{StaticResource PlaybackBigCoverArtStyle}"/>
+        <Image Source="{Binding CoverArt, Converter={StaticResource CoverArtConverter}}" Style="{StaticResource PlaybackBigCoverArtStyle}"/>
         <StackPanel Grid.Row="1" Style="{StaticResource FilterPanelStyle}">
             <TextBlock Text="Type the name of a song or artist bellow: " Style="{StaticResource FilterInstructionsStyle}"/>
             <StackPanel Style="{StaticResource FilterInputPanelStyle}">

--- a/Client/Playback/Playback/SnappedAudio.xaml
+++ b/Client/Playback/Playback/SnappedAudio.xaml
@@ -22,7 +22,7 @@
 
         <TextBlock Style="{StaticResource SnappedAppNameStyle}">Subsonic8</TextBlock>
 
-        <Image Grid.Row="1" Source="{Binding CoverArt}" Stretch="Uniform"/>
+        <Image Grid.Row="1" Source="{Binding CoverArt, Converter={StaticResource CoverArtConverter}}" Stretch="Uniform"/>
 
         <StackPanel Grid.Row="2" Style="{StaticResource SnappedArtistDetailsPanelStyle}">
             <TextBlock Text="{Binding Path=ActiveItem.Artist}" Style="{StaticResource SnappedTitleStyle}" Visibility="{Binding Path=ActiveItem, Converter={StaticResource NullToVisibilityConverter}}"/>

--- a/Client/Playback/PlaybackViewModel.cs
+++ b/Client/Playback/PlaybackViewModel.cs
@@ -530,23 +530,45 @@
             var dispatcher = Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher;
             await dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, async () =>
                     {
-                        var writeableBitmap = new WriteableBitmap(1, 1);
-                        var streamTask = coverArt == CoverArtPlaceholderLarge
-                                             ? GetStreamFromFile(coverArt)
-                                             : GetStreamFromUri(coverArt);
-                        using (var stream = await streamTask)
+                        try
                         {
-                            writeableBitmap = await writeableBitmap.FromStream(stream);
-                            var bluredImage = writeableBitmap.Convolute(Gaussian11X11Kernel);
-                            BluredCoverArt = bluredImage;
+                            var writeableBitmap = new WriteableBitmap(1, 1);
+                            var streamTask = coverArt == CoverArtPlaceholderLarge
+                                                 ? GetStreamFromFile(coverArt)
+                                                 : GetStreamFromUri(coverArt);
+                            using (var stream = await streamTask)
+                            {
+                                writeableBitmap = await writeableBitmap.FromStream(stream);
+                                var bluredImage = writeableBitmap.Convolute(Gaussian11X11Kernel);
+                                BluredCoverArt = bluredImage;
+                            }
+                        }
+                        catch
+                        {
+                            // 图片下载失败时使用占位符
+                            try
+                            {
+                                var writeableBitmap = new WriteableBitmap(1, 1);
+                                using (var stream = await GetStreamFromFile(CoverArtPlaceholderLarge))
+                                {
+                                    writeableBitmap = await writeableBitmap.FromStream(stream);
+                                    var bluredImage = writeableBitmap.Convolute(Gaussian11X11Kernel);
+                                    BluredCoverArt = bluredImage;
+                                }
+                            }
+                            catch { }
                         }
                     });
         }
 
         private static async Task<IRandomAccessStream> GetStreamFromUri(string coverArt)
         {
-            var streamReference = RandomAccessStreamReference.CreateFromUri(new Uri(coverArt, UriKind.Absolute));
-            return await streamReference.OpenReadAsync();
+            // 通过限流阀控制请求
+            return await Client.Common.Services.RequestThrottler.ExecuteAsync(async () =>
+            {
+                var streamReference = RandomAccessStreamReference.CreateFromUri(new Uri(coverArt, UriKind.Absolute));
+                return await streamReference.OpenReadAsync();
+            });
         }
 
         private static async Task<IRandomAccessStream> GetStreamFromFile(string file)

--- a/Client/PlaylistItem/PlaylistItem/NotPlaying.xaml
+++ b/Client/PlaylistItem/PlaylistItem/NotPlaying.xaml
@@ -19,7 +19,7 @@
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
-        <Image Source="{Binding CoverArtUrl}" Style="{StaticResource PlaylistItemCoverArtStyle}" />
+        <Image Source="{Binding CoverArtUrl, Converter={StaticResource CoverArtConverter}}" Style="{StaticResource PlaylistItemCoverArtStyle}" />
 
         <Grid Grid.Column="1" Style="{StaticResource PlaylistItemDetailsGridStyle}">
             <Grid.ColumnDefinitions>

--- a/Client/Playlists/SavePlaylistViewModel.cs
+++ b/Client/Playlists/SavePlaylistViewModel.cs
@@ -141,12 +141,12 @@
             CanEdit = true;
         }
 
-        private static int ExtractId(PlaylistItem item)
+        private static string ExtractId(PlaylistItem item)
         {
-            return int.Parse(item.Uri.ExtractParamterFromQuery("id"));
+            return item.Uri.ExtractParamterFromQuery("id");
         }
 
-        private IEnumerable<int> GetSongIdsForActivePlaylist()
+        private IEnumerable<string> GetSongIdsForActivePlaylist()
         {
             return PlaylistManagementService.Items.Select(ExtractId);
         }

--- a/Client/Settings/SettingsView.xaml
+++ b/Client/Settings/SettingsView.xaml
@@ -31,7 +31,15 @@
             </ToggleSwitch.HeaderTemplate>
         </ToggleSwitch>
 
+        <TextBlock Text="Cache" Style="{StaticResource SettingsTextStyle}" Margin="0,20,0,0" />
+        <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
+            <TextBlock Text="Cache Size: " Style="{StaticResource BodyTextBlockStyle}" VerticalAlignment="Center" />
+            <TextBlock Text="{Binding CacheSize}" FontWeight="Bold" Style="{StaticResource BodyTextBlockStyle}" VerticalAlignment="Center" />
+        </StackPanel>
+        <Button x:Name="CleanCache" Style="{StaticResource LightButton}" Content="Clean Cache" 
+                Margin="0,10,0,0" HorizontalAlignment="Left" />
+
         <Button x:Name="ApplyChanges" Style="{StaticResource LightButton}" Width="100" Content="Save"
-                HorizontalAlignment="Right" />
+                HorizontalAlignment="Right" Margin="0,20,0,0" />
     </StackPanel>
 </UserControl>

--- a/Common.Mocks/MockSubsonicService.cs
+++ b/Common.Mocks/MockSubsonicService.cs
@@ -51,14 +51,14 @@
             return "http://test.mock";
         }
 
-        public override Uri GetUriForFileWithId(int id)
+        public override Uri GetUriForFileWithId(string id)
         {
             GetUriForFileWithIdCallCount++;
 
             return new Uri(string.Format("http://subsonic.org?id={0}", id));
         }
 
-        public override Uri GetUriForVideoWithId(int id, int timeOffset = 0, int maxBitrate = 0)
+        public override Uri GetUriForVideoWithId(string id, int timeOffset = 0, int maxBitrate = 0)
         {
             GetUriForVideoWithIdCallCount++;
 

--- a/Common.Mocks/Results/MockGetSongResult.cs
+++ b/Common.Mocks/Results/MockGetSongResult.cs
@@ -8,9 +8,9 @@
     {
         #region Constructors and Destructors
 
-        public MockGetSongResult(int id = 0)
+        public MockGetSongResult(string id = null)
         {
-            GetResultFunc = () => new Song { Id = id };
+            GetResultFunc = () => new Song { Id = id ?? string.Empty };
         }
 
         #endregion

--- a/Common/Results/RemoteXmlResultBase.cs
+++ b/Common/Results/RemoteXmlResultBase.cs
@@ -140,37 +140,62 @@
 
         private async Task<HttpStreamResult> GetResource()
         {
-            var result = new HttpStreamResult();
-            try
+            const int maxRetries = 3;
+            int delay = 1000; // 起始延迟 1 秒
+
+            for (int attempt = 0; attempt <= maxRetries; attempt++)
             {
-                var httpRequestMessage = CreateRequest();
-                var response = await Client.SendAsync(httpRequestMessage);
-                if (response.IsSuccessStatusCode)
+                var result = new HttpStreamResult();
+                try
                 {
-                    result.Stream = await response.Content.ReadAsStreamAsync();
+                    var httpRequestMessage = CreateRequest();
+                    var response = await Client.SendAsync(httpRequestMessage);
+                    
+                    // 处理可重试的错误状态码: 429, 502, 503
+                    var statusCode = (int)response.StatusCode;
+                    if (statusCode == 429 || statusCode == 502 || statusCode == 503)
+                    {
+                        if (attempt < maxRetries)
+                        {
+                            await Task.Delay(delay);
+                            delay *= 2; // 指数退避
+                            continue;
+                        }
+                        throw new CommunicationException(
+                            string.Format("Server returned {0} after multiple retries.", response.StatusCode));
+                    }
+                    
+                    if (response.IsSuccessStatusCode)
+                    {
+                        result.Stream = await response.Content.ReadAsStreamAsync();
+                    }
+                    else
+                    {
+                        throw new CommunicationException(
+                            string.Format(
+                                "Response was:\r\nStatus Code: {0}\r\nReason: {1}", response.StatusCode, response.ReasonPhrase));
+                    }
+                    
+                    return result;
                 }
-                else
+                catch (HttpRequestException exception)
                 {
-                    throw new CommunicationException(
-                        string.Format(
-                            "Response was:\r\nStatus Code: {0}\r\nReason: {1}", response.StatusCode, response.ReasonPhrase));
+                    var innerMessage = exception.InnerException != null
+                                           ? exception.Message + "\r\n" + exception.InnerException.Message
+                                           : exception.Message;
+                    result.Exception =
+                        new CommunicationException(
+                            string.Format("Could not perform Http request.\r\nMessage:\r\n{0}", innerMessage), exception);
+                    return result;
                 }
-            }
-            catch (HttpRequestException exception)
-            {
-                var innerMessage = exception.InnerException != null
-                                       ? exception.Message + "\r\n" + exception.InnerException.Message
-                                       : exception.Message;
-                result.Exception =
-                    new CommunicationException(
-                        string.Format("Could not perform Http request.\r\nMessage:\r\n{0}", innerMessage), exception);
-            }
-            catch (Exception exception)
-            {
-                result.Exception = exception;
+                catch (Exception exception)
+                {
+                    result.Exception = exception;
+                    return result;
+                }
             }
 
-            return result;
+            return new HttpStreamResult { Exception = new CommunicationException("Max retries exceeded.") };
         }
 
         #endregion


### PR DESCRIPTION
1. 把内置函数的int类型转为string类型来兼容Navidrome使用的md5
2. 创建图片缓存机制, 减少对服务器的请求
3. 创建同时请求上限避免触发服务器429
4. indexviewmodel里加入null时的处理避免空指针异常导致程序冻结卡死
(删除了storeapp xaml方便debug)